### PR TITLE
fix: implement sound operation lock to avoid stop audio seg-fault

### DIFF
--- a/src/ios/CDVSound.h
+++ b/src/ios/CDVSound.h
@@ -75,12 +75,14 @@ typedef NSUInteger CDVMediaMsg;
 
 @interface CDVSound : CDVPlugin <AVAudioPlayerDelegate, AVAudioRecorderDelegate> {
   NSMutableDictionary *soundCache;
+  NSLock *soundOperationLock;
   NSString *currMediaId;
   AVAudioSession *avSession;
   AVPlayer *avPlayer;
   NSString *statusCallbackId;
 }
 @property (nonatomic, strong) NSMutableDictionary *soundCache;
+@property (nonatomic, strong) NSLock *soundOperationLock;
 @property (nonatomic, strong) AVAudioSession *avSession;
 @property (nonatomic, strong) NSString *currMediaId;
 @property (nonatomic, strong) NSString *statusCallbackId;

--- a/src/ios/CDVSound.m
+++ b/src/ios/CDVSound.m
@@ -36,9 +36,7 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 
 - (void)pluginInitialize
 {
-  NSLog(@"------- CDVSound: pluginInitialize test 1");
   self.soundOperationLock = [[NSLock alloc] init];
-  NSLog(@"------- CDVSound: pluginInitialize, soundOperationLock: %@", self.soundOperationLock);
 
   NSDictionary *settings = self.commandDelegate.settings;
   keepAvAudioSessionAlwaysActive =
@@ -389,7 +387,6 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 - (void)startPlayingAudio:(CDVInvokedUrlCommand *)command
 {
   [self.commandDelegate runInBackground:^{
-    NSLog(@"------- CDVSound: soundOperationLock, %@", self.soundOperationLock);
     [self.soundOperationLock lock];
     NSString *callbackId = command.callbackId;
 #pragma unused(callbackId)
@@ -566,7 +563,6 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 
 - (void)stopPlayingAudio:(CDVInvokedUrlCommand *)command
 {
-  NSLog(@"------- CDVSound: soundOperationLock, %@", self.soundOperationLock);
   [self.soundOperationLock lock];
   NSString *mediaId = [command argumentAtIndex:0];
   CDVAudioFile *audioFile = [[self soundCache] objectForKey:mediaId];
@@ -622,7 +618,6 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 
 - (void)seekToAudio:(CDVInvokedUrlCommand *)command
 {
-  NSLog(@"------- CDVSound: soundOperationLock, %@", self.soundOperationLock);
   [self.soundOperationLock lock];
   // args:
   // 0 = Media id
@@ -684,7 +679,6 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 
 - (void)release:(CDVInvokedUrlCommand *)command
 {
-  NSLog(@"------- CDVSound: soundOperationLock, %@", self.soundOperationLock);
   [self.soundOperationLock lock];
   NSString *mediaId = [command argumentAtIndex:0];
   // NSString* mediaId = self.currMediaId;
@@ -740,7 +734,6 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 
 - (void)startRecordingAudio:(CDVInvokedUrlCommand *)command
 {
-  NSLog(@"------- CDVSound: soundOperationLock, %@", self.soundOperationLock);
   [self.soundOperationLock lock];
   NSString *callbackId = command.callbackId;
 #pragma unused(callbackId)
@@ -863,7 +856,6 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 
 - (void)stopRecordingAudio:(CDVInvokedUrlCommand *)command
 {
-  NSLog(@"------- CDVSound: soundOperationLock, %@", self.soundOperationLock);
   [self.soundOperationLock lock];
   NSString *mediaId = [command argumentAtIndex:0];
 
@@ -943,7 +935,6 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 
 - (void)onMemoryWarning
 {
-  NSLog(@"------- CDVSound: soundOperationLock, %@", self.soundOperationLock);
   [self.soundOperationLock lock];
   /* https://issues.apache.org/jira/browse/CB-11513 */
   NSMutableArray *keysToRemove = [[NSMutableArray alloc] init];
@@ -977,7 +968,6 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 
 - (void)onReset
 {
-  NSLog(@"------- CDVSound: soundOperationLock, %@", self.soundOperationLock);
   [self.soundOperationLock lock];
   for (CDVAudioFile *audioFile in [[self soundCache] allValues]) {
     if (audioFile != nil) {
@@ -997,7 +987,6 @@ BOOL keepAvAudioSessionAlwaysActive = NO;
 
 - (void)getCurrentAmplitudeAudio:(CDVInvokedUrlCommand *)command
 {
-  NSLog(@"------- CDVSound: soundOperationLock, %@", self.soundOperationLock);
   [self.soundOperationLock lock];
   NSString *callbackId = command.callbackId;
   NSString *mediaId = [command argumentAtIndex:0];


### PR DESCRIPTION
# Description
We have been having tons of iOS app crashes for months. I have tracked them down to this plugin. There is more context here: [Mobile app crashes notes](https://www.notion.so/slangapp/Mobile-app-crashes-notes-bb1fa383f6774759aab6c0a1704db756).

This PR implements a lock (`NSLock`) for the points where I suspect multiple threads are accessing the stop operation, which provokes a segfault at some point in the program execution. After I added [Sentry Capacitor](https://github.com/lengio/slang-ui/pull/1464) we started getting more info there, you can check the crashes by looking for `EXC_BAD_ACCESS`.

I tested this locally using the QA tools and going through the activities flow and everything is working well.

- [Notion task](https://www.notion.so/slangapp/iOS-crashes-e46d100f58f649c795e58ae1ca6d7866)
- [164. iOS crash report](https://www.notion.so/slangapp/164-IOS-crash-5912a84f281c48349b56a33caf170bec)